### PR TITLE
fix: robustly parse quoted ssh raw commands (#28)

### DIFF
--- a/core/sshd/sshd.go
+++ b/core/sshd/sshd.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/alibabacloud-go/tea/tea"
+	"github.com/anmitsu/go-shlex"
 	"github.com/elfgzp/ssh"
 	"github.com/fatih/color"
 	"github.com/helloyi/go-sshclient"
@@ -271,7 +272,16 @@ func getSignerFromBase64(key string) (gossh.Signer, error) {
 
 // ParseRawCommand ParseRawCommand
 func ParseRawCommand(command string) (string, []string, error) {
-	parts := strings.Split(command, " ")
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return "", nil, errors.New("No command in payload: " + command)
+	}
+
+	parts, err := shlex.Split(command, true)
+	if err != nil {
+		return "", nil, err
+	}
+
 	if len(parts) < 1 {
 		return "", nil, errors.New("No command in payload: " + command)
 	}

--- a/core/sshd/sshd_test.go
+++ b/core/sshd/sshd_test.go
@@ -1,0 +1,63 @@
+package sshd
+
+import "testing"
+
+func TestParseRawCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		wantCmd string
+		wantArg []string
+		wantErr bool
+	}{
+		{
+			name:    "empty command",
+			command: "   ",
+			wantErr: true,
+		},
+		{
+			name:    "single command",
+			command: "ssh",
+			wantCmd: "ssh",
+			wantArg: []string{},
+		},
+		{
+			name:    "scp path with spaces in quotes",
+			command: `scp -t "root@1.1.1.1:/tmp/a b.txt"`,
+			wantCmd: "scp",
+			wantArg: []string{"-t", "root@1.1.1.1:/tmp/a b.txt"},
+		},
+		{
+			name:    "command with escaped quote",
+			command: `exec "ssh-rsa AAAA\"test comment"`,
+			wantCmd: "exec",
+			wantArg: []string{"ssh-rsa AAAA\"test comment"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCmd, gotArg, err := ParseRawCommand(tt.command)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseRawCommand() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseRawCommand() error = %v", err)
+			}
+			if gotCmd != tt.wantCmd {
+				t.Fatalf("ParseRawCommand() cmd = %q, want %q", gotCmd, tt.wantCmd)
+			}
+			if len(gotArg) != len(tt.wantArg) {
+				t.Fatalf("ParseRawCommand() args len = %d, want %d (%v)", len(gotArg), len(tt.wantArg), gotArg)
+			}
+			for i := range gotArg {
+				if gotArg[i] != tt.wantArg[i] {
+					t.Fatalf("ParseRawCommand() args[%d] = %q, want %q", i, gotArg[i], tt.wantArg[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation

- SSH raw command parsing previously used naive `strings.Split`, which broke when arguments contained spaces or quoted/escaped characters and caused incorrect handling of commands like `scp` and `exec`.

### Description

- Replace naive splitting with shell-aware parsing using `github.com/anmitsu/go-shlex` in `ParseRawCommand` and add input trimming and empty-command validation.
- Import `github.com/anmitsu/go-shlex` and handle parsing errors returned by the shlex splitter.
- Add unit tests covering empty input, single-command, quoted `scp` destination with spaces, and an argument with an escaped quote in `core/sshd/sshd_test.go`.

### Testing

- Ran `go test ./core/sshd`, which passed (`ok   github.com/xops-infra/jms/core/sshd`).
- A full `go test ./...` run still fails in other packages due to missing runtime test config (`open /opt/jms/config.yaml: no such file or directory`) unrelated to the `sshd` changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b37fe53410832eaf2fdcc2c98dc7cb)