### PR TITLE
fix(scp): resolve target by flag position instead of args[1]

### DIFF
--- a/core/sshd/scp.go
+++ b/core/sshd/scp.go
@@ -83,6 +83,23 @@ func (r *response) GetMessage() string {
 	return r.Message
 }
 
+// scpTarget 定位 -t/-f 标志并返回其后紧跟的目标参数。
+// 之前实现固定取 args[1]，当命令包含额外 flag（如 scp -v -t <target>，
+// OpenSSH 在带 -v 调试或部分客户端下会注入）时，args[1] 会是 flag 本身而非目标，
+// 导致 ExtractIP 报 "no IP address found in input" 并断开。
+// 这里改为按 flag 的位置取下一个参数，兼容任意前置 flag。
+func scpTarget(args []string) (string, error) {
+	for i, arg := range args {
+		if arg == "-t" || arg == "-f" {
+			if i+1 >= len(args) {
+				return "", fmt.Errorf("scp: missing target after %s", arg)
+			}
+			return args[i+1], nil
+		}
+	}
+	return "", errors.New("scp: neither -t nor -f flag found in args")
+}
+
 // ExecuteSCP ExecuteSCP
 func ExecuteSCP(args []string, clientSess *ssh.Session) error {
 	defer func() {
@@ -103,14 +120,19 @@ func ExecuteSCP(args []string, clientSess *ssh.Session) error {
 	for _, arg := range args {
 		if arg == "-t" || arg == "-f" {
 			log.Debugf("arg: %s", arg)
+			target, err := scpTarget(args)
+			if err != nil {
+				replyErr(*clientSess, err)
+				return err
+			}
 			switch arg {
 			case "-t":
-				err := app.App.Sshd.SshdIO.CheckPermission(args[1], user, Upload)
+				err := app.App.Sshd.SshdIO.CheckPermission(target, user, Upload)
 				if err != nil {
 					replyErr(*clientSess, err)
 					return err
 				}
-				err = copyToServer(args, clientSess)
+				err = copyToServer(args, target, clientSess)
 				if err != nil {
 					replyErr(*clientSess, err)
 					return err
@@ -118,12 +140,12 @@ func ExecuteSCP(args []string, clientSess *ssh.Session) error {
 				(*clientSess).Close()
 				return nil
 			case "-f":
-				err := app.App.Sshd.SshdIO.CheckPermission(args[1], user, Download)
+				err := app.App.Sshd.SshdIO.CheckPermission(target, user, Download)
 				if err != nil {
 					replyErr(*clientSess, err)
 					return err
 				}
-				err = copyFromServer(args, clientSess)
+				err = copyFromServer(target, clientSess)
 				if err != nil {
 					replyErr(*clientSess, err)
 					return err
@@ -136,7 +158,7 @@ func ExecuteSCP(args []string, clientSess *ssh.Session) error {
 	return errors.New("this feature is not currently supported")
 }
 
-func copyToServer(args []string, clientSess *ssh.Session) error {
+func copyToServer(args []string, target string, clientSess *ssh.Session) error {
 	err := replyOk(*clientSess)
 	if err != nil {
 		return err
@@ -163,7 +185,7 @@ func copyToServer(args []string, clientSess *ssh.Session) error {
 			return fmt.Errorf("unexpected count in reading start directory message header: n=%d", 3)
 		}
 
-		err = copyFileToServer(bufferedReader, size, filename, args[1], perm, clientSess)
+		err = copyFileToServer(bufferedReader, size, filename, target, perm, clientSess)
 		if err != nil {
 			return err
 		}
@@ -171,7 +193,7 @@ func copyToServer(args []string, clientSess *ssh.Session) error {
 			err = app.App.DBIo.AddScpRecord(&AddScpRecordRequest{
 				Action: tea.String("upload"),
 				From:   tea.String(filename),
-				To:     tea.String(args[1]), // root@10.9.x.x:/data/xx.zip
+				To:     tea.String(target), // root@10.9.x.x:/data/xx.zip
 				User:   tea.String((*clientSess).User()),
 				Client: tea.String((*clientSess).RemoteAddr().String()),
 			})
@@ -180,7 +202,7 @@ func copyToServer(args []string, clientSess *ssh.Session) error {
 			}
 		}
 
-		log.Infof("user %s upload file %s to %s success", (*clientSess).User(), filename, args[1])
+		log.Infof("user %s upload file %s to %s success", (*clientSess).User(), filename, target)
 		return nil
 	case flagEndDirectory:
 	case flagStartDirectory:
@@ -192,8 +214,8 @@ func copyToServer(args []string, clientSess *ssh.Session) error {
 	return nil
 }
 
-func copyFromServer(args []string, sess *ssh.Session) error {
-	sshUser, server, filePath, err := app.App.Sshd.SshdIO.GetSSHUserAndServerByScpPath(args[1])
+func copyFromServer(target string, sess *ssh.Session) error {
+	sshUser, server, filePath, err := app.App.Sshd.SshdIO.GetSSHUserAndServerByScpPath(target)
 	if err != nil {
 		return err
 	}
@@ -291,7 +313,7 @@ func copyFromServer(args []string, sess *ssh.Session) error {
 				err = app.App.DBIo.AddScpRecord(&AddScpRecordRequest{
 					Action: tea.String("download"),
 					To:     tea.String(filename),
-					From:   tea.String(args[1]), // root@10.9.x.x:/data/xxx.json
+					From:   tea.String(target), // root@10.9.x.x:/data/xxx.json
 					User:   tea.String((*sess).User()),
 					Client: tea.String((*sess).RemoteAddr().String()),
 				})
@@ -299,7 +321,7 @@ func copyFromServer(args []string, sess *ssh.Session) error {
 					log.Errorf("record scp download file to db failed: %v", err)
 				}
 			}
-			log.Infof("user %s download file %s from %s success", (*sess).User(), filename, args[1])
+			log.Infof("user %s download file %s from %s success", (*sess).User(), filename, target)
 			return
 		case flagEndDirectory:
 		case flagStartDirectory:

--- a/core/sshd/scp_test.go
+++ b/core/sshd/scp_test.go
@@ -1,0 +1,68 @@
+package sshd
+
+import "testing"
+
+func TestScpTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "upload without extra flags",
+			args: []string{"-t", "root@10.193.18.8:/root/lw/"},
+			want: "root@10.193.18.8:/root/lw/",
+		},
+		{
+			name: "download without extra flags",
+			args: []string{"-f", "root@10.193.18.8:/root/lw/pdf.zip"},
+			want: "root@10.193.18.8:/root/lw/pdf.zip",
+		},
+		{
+			// 复现线上问题：客户端加 -v 调试时 OpenSSH 注入 -v，
+			// 旧实现固定取 args[1] 会得到 "-t"，导致 no IP address found。
+			name: "upload with -v injected before -t",
+			args: []string{"-v", "-t", "root@10.193.18.8#key_name=demo:/root/lw/"},
+			want: "root@10.193.18.8#key_name=demo:/root/lw/",
+		},
+		{
+			name: "download with -v injected before -f",
+			args: []string{"-v", "-f", "root@10.193.18.8:/root/lw/pdf.zip"},
+			want: "root@10.193.18.8:/root/lw/pdf.zip",
+		},
+		{
+			name: "multiple flags before -t",
+			args: []string{"-v", "-r", "-t", "root@10.193.18.8:/data/"},
+			want: "root@10.193.18.8:/data/",
+		},
+		{
+			name:    "missing target after -t",
+			args:    []string{"-v", "-t"},
+			wantErr: true,
+		},
+		{
+			name:    "no scp mode flag",
+			args:    []string{"-v", "root@10.193.18.8:/data/"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := scpTarget(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("scpTarget(%v) expected error, got nil", tt.args)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("scpTarget(%v) error = %v", tt.args, err)
+			}
+			if got != tt.want {
+				t.Fatalf("scpTarget(%v) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 问题

通过 jms 跳板执行 `scp` 时，若客户端在 `-t`/`-f` 前注入额外 flag（最常见是加 `-v` 调试：`scp -v -t <target>`），传输会被丢弃并报 `no IP address found in input`，即使命令本身完全合法。线上已复现：用户上传 `layout_ocr/pdf.zip` 加 `-v` 抓日志时命中，服务端 `Sending command: scp -v -t root@...` 后立即 `no IP address found in input`。

## 根因

`ExecuteSCP`、`copyToServer`、`copyFromServer` 固定用 `args[1]` 当作 SCP 目标。`args` 来自 `ParseRawCommand` 的 `parts[1:]`（不含 `scp`）：

- 正常 `scp -t <target>` → `args = ["-t", "<target>"]`，`args[1]` 恰好是目标 ✅
- 注入 flag `scp -v -t <target>` → `args = ["-v", "-t", "<target>"]`，`args[1]` 变成 `"-t"` ❌

于是 `ExtractIP` 拿到的是 flag 而非地址，提取失败。

## 修复

新增 `scpTarget(args)`：遍历定位 `-t`/`-f`，返回其**后一个**参数（带越界保护），取代所有硬编码的 `args[1]`；并把解析出的 `target` 贯穿到 copy helpers 与审计记录。兼容任意前置 flag。

## 测试

- `go vet ./core/sshd/` 干净
- `go build ./...` 通过
- `go test ./core/sshd/`：新增 `TestScpTarget` 7 个用例（含 `-v` 注入、缺 target、无 flag 边界）+ 原有 `TestParseRawCommand` 全部 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)