### PR TITLE
feat(ldap): support ldaps and StartTLS connections

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -40,6 +40,9 @@ withLdap:
   enable: false
   host: "xxx"
   port: 389
+  use_ssl: false
+  start_tls: false
+  ssl_skip_verify: false
   baseDN: "dc=corp,dc=xxx,dc=com"
   bindUser: "xx"
   bindPassword: "xxx"

--- a/model/config.go
+++ b/model/config.go
@@ -153,6 +153,9 @@ type WithLdap struct {
 	BindPassword     string   `mapstructure:"bindPassword"`
 	Host             string   `mapstructure:"host"`
 	Port             int      `mapstructure:"port"`
+	UseSSL           bool     `mapstructure:"use_ssl"`
+	StartTLS         bool     `mapstructure:"start_tls"`
+	SSLSkipVerify    bool     `mapstructure:"ssl_skip_verify"`
 	BaseDN           string   `mapstructure:"baseDN"`
 	UserSearchFilter string   `mapstructure:"userSearchFilter"`
 	Attributes       []string `mapstructure:"attributes"`

--- a/utils/ldap.go
+++ b/utils/ldap.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"crypto/tls"
 	"fmt"
 
 	"github.com/go-ldap/ldap"
@@ -8,15 +9,46 @@ import (
 	"github.com/xops-infra/noop/log"
 )
 
+func dialLdap(config model.WithLdap) (*ldap.Conn, error) {
+	addr := fmt.Sprintf("%s:%d", config.Host, config.Port)
+	if config.UseSSL {
+		tlsConfig := &tls.Config{
+			ServerName:         config.Host,
+			InsecureSkipVerify: config.SSLSkipVerify,
+		}
+		conn, err := ldap.DialTLS("tcp", addr, tlsConfig)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to connect to LDAP server via ldaps: %s", err.Error())
+		}
+		return conn, nil
+	}
+
+	conn, err := ldap.Dial("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to connect to LDAP server: %s", err.Error())
+	}
+	if config.StartTLS {
+		tlsConfig := &tls.Config{
+			ServerName:         config.Host,
+			InsecureSkipVerify: config.SSLSkipVerify,
+		}
+		if err := conn.StartTLS(tlsConfig); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("Failed to start TLS on LDAP connection: %s", err.Error())
+		}
+	}
+	return conn, nil
+}
+
 type Ldap struct {
 	Conn   *ldap.Conn
 	Config model.WithLdap
 }
 
 func NewLdap(config model.WithLdap) (*Ldap, error) {
-	ldapConn, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", config.Host, config.Port))
+	ldapConn, err := dialLdap(config)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to connect to LDAP server: %s", err.Error())
+		return nil, err
 	}
 	err = ldapConn.Bind(config.BindUser, config.BindPassword)
 	if err != nil {
@@ -29,9 +61,9 @@ func NewLdap(config model.WithLdap) (*Ldap, error) {
 }
 
 func (l *Ldap) refreshLdap() error {
-	ldapConn, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", l.Config.Host, l.Config.Port))
+	ldapConn, err := dialLdap(l.Config)
 	if err != nil {
-		return fmt.Errorf("Failed to connect to LDAP server: %s", err.Error())
+		return err
 	}
 	err = ldapConn.Bind(l.Config.BindUser, l.Config.BindPassword)
 	if err != nil {


### PR DESCRIPTION
## Summary
- WithLdap 配置新增 use_ssl / start_tls / ssl_skip_verify 三个字段
- host+port 使用 ldaps (SSL隧道) 或 StartTLS 方式连接 LDAP 服务器，支持类似 636 端口的加密登录场景
- 更新 config.yaml 示例配置

## Test plan
- [x] go build ./...
- [x] go vet ./utils/... ./model/...
- [ ] 实际 ldaps 环境连通性未验证（无可用测试环境）